### PR TITLE
Visitors cannot add developers more than once

### DIFF
--- a/app/controllers/tribes_controller.rb
+++ b/app/controllers/tribes_controller.rb
@@ -4,6 +4,7 @@ class TribesController < ApplicationController
     developer = Developer.find(params[:developer_id])
     flash[:notice] = "#{developer.name} has joined your tribe!"
 
+    developer.update_attribute(:status, "unavailable")
     session[:tribe] ||= []
     session[:tribe] << developer.id
 
@@ -14,7 +15,7 @@ class TribesController < ApplicationController
     @developers = session[:tribe].map do |developer_id|
       Developer.find(developer_id)
     end
-    
+
     @total = @developers.reduce(0) do |acc, developer|
       acc + developer.rate.to_i
     end

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -3,4 +3,5 @@
 <%= @developer.name %>
 <%= @developer.specialty %>
 <%= @developer.rate %>
-<%= button_to "Add to tribe", tribe_path(developer_id: @developer.id) %>
+<%= button_to("Add to tribe", tribe_path(developer_id: @developer.id)) if @developer.status == "available" %>
+<%= "#{@developer.name} is unavailable" if @developer.status == "unavailable" %>

--- a/db/migrate/20160112210633_add_status_to_developers.rb
+++ b/db/migrate/20160112210633_add_status_to_developers.rb
@@ -1,0 +1,5 @@
+class AddStatusToDevelopers < ActiveRecord::Migration
+  def change
+    add_column :developers, :status, :string, default: "available"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160111232202) do
+ActiveRecord::Schema.define(version: 20160112210633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,8 +21,9 @@ ActiveRecord::Schema.define(version: 20160111232202) do
     t.string   "profile_picture"
     t.string   "specialty"
     t.float    "rate"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.string   "status",          default: "available"
   end
 
 end

--- a/test/integration/visitor_adds_developers_to_cart_test.rb
+++ b/test/integration/visitor_adds_developers_to_cart_test.rb
@@ -23,6 +23,21 @@ class VisitorAddsDevelopersToCartTest < ActionDispatch::IntegrationTest
     assert page.has_content?("10")
     assert page.has_content?("Total: 10")
   end
+
+  test "a visitor cannot add the same developer to the cart" do
+    developers = create_list(:developer, 4)
+
+    visit developer_path(developers[0])
+
+    assert_equal current_path, developer_path(developers[0])
+
+    click_on "Add to tribe"
+
+    visit developer_path(developers[0])
+
+    refute page.has_content?("Add to tribe")
+    assert page.has_content?("Dev1 is unavailable")
+  end
 end
 
 # Background: Developers, and a user that is not logged in


### PR DESCRIPTION
Implements a 'status' attribute for developers which defaults to 'available' but goes to 'unavailable' if they get hired.