### PR TITLE
Visitor returned to point of origin when adding dev to tribe

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,11 @@ class ApplicationController < ActionController::Base
 
   after_action :stash_pending_tribe
 
-  helper_method :current_user?, :current_contractor, :current_pending_tribe
+  helper_method :current_user?, :current_contractor, :current_pending_tribe, :current_specialty
+
+  def current_specialty
+    @current_session ||= Specialty.find(session[:specialty]) if session[:specialty]
+  end
 
   def current_pending_tribe
     @pending_tribe ||= PendingTribe.new(session[:tribe])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,14 @@ class ApplicationController < ActionController::Base
 
   after_action :stash_pending_tribe
 
-  helper_method :current_user?, :current_contractor, :current_pending_tribe, :current_specialty
+  helper_method :current_user?,
+                :current_contractor,
+                :current_pending_tribe,
+                :current_specialty
 
   def current_specialty
-    @current_session ||= Specialty.find(session[:specialty]) if session[:specialty]
+    @current_specialty ||=
+            Specialty.find(session[:specialty]) if session[:specialty]
   end
 
   def current_pending_tribe
@@ -33,10 +37,12 @@ class ApplicationController < ActionController::Base
   end
 
   def current_developer
-    @current_developer ||= Contractor.find(session[:developer_id]) if session[:developer_id]
+    @current_developer ||=
+          Contractor.find(session[:developer_id]) if session[:developer_id]
   end
 
   def current_contractor
-    @current_contractor ||= Contractor.find(session[:contractor_id]) if session[:contractor_id]
+    @current_contractor ||=
+          Contractor.find(session[:contractor_id]) if session[:contractor_id]
   end
 end

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -1,5 +1,6 @@
 class DevelopersController < ApplicationController
   def index
+    session[:specialty] = nil
     @developers = Developer.all
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -25,8 +25,7 @@ class ProjectsController < ApplicationController
   end
 
   def remove_dev
-    developer = Developer.find(params[:dev])
-    Project.find(params[:project_id]).developers -= [developer]
+    Project.find(params[:project_id]).remove(params[:dev])
     redirect_to contractor_project_path(params[:project_id])
   end
 

--- a/app/controllers/specialties_controller.rb
+++ b/app/controllers/specialties_controller.rb
@@ -1,5 +1,6 @@
 class SpecialtiesController < ApplicationController
   def show
-    @developers = Specialty.find_by(url_name: params[:id]).developers
+    session[:specialty] = Specialty.find_by(url_name: params[:id]).id
+    @developers = current_specialty.developers
   end
 end

--- a/app/controllers/tribes_controller.rb
+++ b/app/controllers/tribes_controller.rb
@@ -4,7 +4,12 @@ class TribesController < ApplicationController
     developer = Developer.find(params[:developer_id])
     flash[:notice] = "#{developer.name} has joined your tribe!"
     current_pending_tribe.add(developer.id)
-    redirect_to developers_path
+
+    if current_specialty
+      redirect_to specialty_path(current_specialty)
+    else
+      redirect_to developers_path
+    end
   end
 
   def show

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -6,8 +6,4 @@ class Developer < ActiveRecord::Base
   def in_pending_tribe?(tribe)
     tribe.developer_ids.include?(id)
   end
-
-  def set_speciality(new_specialty)
-    self.specialty = new_specialty
-  end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -6,4 +6,8 @@ class Developer < ActiveRecord::Base
   def in_pending_tribe?(tribe)
     tribe.developer_ids.include?(id)
   end
+
+  def set_speciality(new_specialty)
+    self.specialty = new_specialty
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,4 +5,8 @@ class Project < ActiveRecord::Base
 
   enum status: ["Pending", "Paid & Active", "Completed", "Cancelled"]
 
+  def remove(developer_id)
+    self.developers -= [developers.find_by(id: developer_id)] 
+  end
+
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,7 +6,6 @@ class Project < ActiveRecord::Base
   enum status: ["Pending", "Paid & Active", "Completed", "Cancelled"]
 
   def remove(developer_id)
-    self.developers -= [developers.find_by(id: developer_id)] 
+    self.developers -= [developers.find_by(id: developer_id)]
   end
-
 end

--- a/app/views/developers/show.html.erb
+++ b/app/views/developers/show.html.erb
@@ -8,6 +8,4 @@
     <li><%= @developer.rate %></li>
   </ul>
   <%= add_or_already_in_tribe  %>
-  <%#= button_to("Add to tribe", tribe_path(developer_id: @developer.id)) unless current_pending_tribe.developer_ids.include?(@developer.id) %>
-  <%#= "#{@developer.name} is unavailable" if current_pending_tribe.developer_ids.include?(@developer.id) %>
 </div>

--- a/test/integration/visitor_adds_developers_to_cart_test.rb
+++ b/test/integration/visitor_adds_developers_to_cart_test.rb
@@ -4,7 +4,7 @@ class VisitorAddsDevelopersToCartTest < ActionDispatch::IntegrationTest
   test "a visitor can add developers to cart from index pages" do
     dev = create(:developer)
 
-    visit developers_path #visit developer_path(@developer)
+    visit developers_path
     click_on "#{dev.name} Bio"
 
     assert_equal current_path, developer_path(developers.first)
@@ -17,7 +17,6 @@ class VisitorAddsDevelopersToCartTest < ActionDispatch::IntegrationTest
 
     click_on "Current Tribe"
     assert_equal current_path, tribe_path
-    # save_and_open_page
     assert page.has_content?("#{dev.name}")
     assert page.has_content?("#{dev.rate.to_i}")
     assert page.has_content?("Total: #{dev.rate.to_i}")
@@ -33,8 +32,19 @@ class VisitorAddsDevelopersToCartTest < ActionDispatch::IntegrationTest
     click_on "Add to tribe"
 
     visit developer_path(dev)
-    # save_and_open_page
+
     refute page.has_content?("Add to tribe")
     assert page.has_content?("#{dev.name} is already in tribe")
+  end
+
+  test "a visitor is redirected to their path of origin when adding to cart" do
+    3.times do
+      dev = create(:developer)
+      visit specialty_path(dev.specialty)
+      click_on "#{dev.name} Bio"
+      click_on "Add to tribe"
+
+      assert_equal specialty_path(dev.specialty), current_path
+    end
   end
 end

--- a/test/integration/visitor_adds_developers_to_cart_test.rb
+++ b/test/integration/visitor_adds_developers_to_cart_test.rb
@@ -46,5 +46,19 @@ class VisitorAddsDevelopersToCartTest < ActionDispatch::IntegrationTest
 
       assert_equal specialty_path(dev.specialty), current_path
     end
+
+    dev = create(:developer)
+    visit developers_path
+    click_on "#{dev.name} Bio"
+    click_on "Add to tribe"
+
+    assert_equal developers_path, current_path
+
+    dev = create(:developer)
+    visit specialty_path(dev.specialty)
+    click_on "#{dev.name} Bio"
+    click_on "Add to tribe"
+
+    assert_equal specialty_path(dev.specialty), current_path
   end
 end


### PR DESCRIPTION
Along with a couple of mini refactors, this request allows someone who gets to a dev show page via a specialty page to be redirected to that page after adding the dev to the tribe.