### PR TITLE
Browse is removed from navbar

### DIFF
--- a/app/views/navbars/_navbar.html.erb
+++ b/app/views/navbars/_navbar.html.erb
@@ -8,8 +8,8 @@
         <%= link_to "View Account: #{current_contractor.first_name}", contractor_path, class: "sidebar-font-profile" if current_contractor %>
         <%= link_to "View Account: #{current_developer.name}", developer_path, class: "sidebar-font-profile" if current_developer %>
       </li>
-      <li><%= link_to "Browse Developers", developers_path %></li>
-      <li><%= link_to "Browse Contractors", developers_path %></li>
+      <li><%= link_to "Developers", developers_path %></li>
+      <li><%= link_to "Contractors", developers_path %></li>
       <li><%= link_to "Current Tribe", tribe_path unless current_developer %></li>
       <li class="divider"></li>
       <li><%= login_or_logout("sidebar-log") %></li>
@@ -24,8 +24,8 @@
     </ul>
 
     <ul id="nav-mobile" class="right hide-on-med-and-down navbar-font">
-      <li><a class="dropdown-button" id="dropdown-font" data-activates="dropdown1">Browse Developers</a></li>
-      <li id="navbar-font"><%= link_to "Browse Contractors", developers_path, id: "navbar-font" %></li>
+      <li><a class="dropdown-button" id="dropdown-font" data-activates="dropdown1">Developers</a></li>
+      <li id="navbar-font"><%= link_to "Contractors", developers_path, id: "navbar-font" %></li>
       <li id="navbar-font"><%= link_to "Current Tribe", tribe_path, id: "navbar-font" unless current_developer %></li>
     </ul>
 

--- a/app/views/navbars/_root_navbar.html.erb
+++ b/app/views/navbars/_root_navbar.html.erb
@@ -8,8 +8,8 @@
         <%= link_to "View Account: #{current_contractor.first_name}", contractor_path, class: "sidebar-font-profile" if current_contractor %>
         <%= link_to "View Account: #{current_developer.name}", developer_path, class: "sidebar-font-profile" if current_developer %>
       </li>
-      <li><%= link_to "Browse Developers", developers_path %></li>
-      <li><%= link_to "Browse Contractors", developers_path %></li>
+      <li><%= link_to "Developers", developers_path %></li>
+      <li><%= link_to "Contractors", developers_path %></li>
       <li><%= link_to "Current Tribe", tribe_path unless current_developer %></li>
       <li class="divider"></li>
       <li><%= login_or_logout("sidebar-log") %></li>
@@ -24,8 +24,8 @@
     </ul>
 
     <ul id="nav-mobile" class="right hide-on-med-and-down navbar-font">
-      <li><a class="dropdown-button" id="dropdown-font" data-activates="dropdown1">Browse Developers</a></li>
-      <li id="navbar-font"><%= link_to "Browse Contractors", developers_path, id: "navbar-font" %></li>
+      <li><a class="dropdown-button" id="dropdown-font" data-activates="dropdown1">Developers</a></li>
+      <li id="navbar-font"><%= link_to "Contractors", developers_path, id: "navbar-font" %></li>
       <li id="navbar-font"><%= link_to "Current Tribe", tribe_path, id: "navbar-font" unless current_developer %></li>
     </ul>
 

--- a/test/integration/admin_has_a_private_dashboard_test.rb
+++ b/test/integration/admin_has_a_private_dashboard_test.rb
@@ -4,13 +4,13 @@ class AdminHasAPrivateDashboardTest < ActionDispatch::IntegrationTest
   test "admin login to their dashboard through contractor form" do
     admin = create(:admin)
     visit login_path
-    # save_and_open_page
+    
     within "#contractor-login-form" do
       fill_in "session[email]", with: admin.email
       fill_in "session[password]", with: admin.password
       click_on "Contractor Login"
     end
-    # save_and_open_page
+    
     assert_equal admin_dashboard_path, current_path
     assert page.has_content? "Admin Dashboard"
 
@@ -48,7 +48,6 @@ class AdminHasAPrivateDashboardTest < ActionDispatch::IntegrationTest
     end
 
     visit '/admin/dashboard'
-    # save_and_open_page
     assert page.has_content? "The page you were looking for doesn't exist"
   end
 


### PR DESCRIPTION
Removes the word "Browse" from navbar and tests for better visual balance.
Removed various commented 'save_and_open_page' instances.